### PR TITLE
Expand languages and POS for Wikidata queries

### DIFF
--- a/_posts/2021-10-04-sparql-query-generator-for-lexicographical-data.md
+++ b/_posts/2021-10-04-sparql-query-generator-for-lexicographical-data.md
@@ -24,12 +24,25 @@ Please note that the translation option is only available for headwords. Also, r
         <div class="form-group">
           <label for="source_language">Source language</label>
           <select class="form-control" id="source_language" name="source_language">
-            <option value="en">English</option>
-            <option value="fr">French</option>
-            <option value="es">Spanish</option>
-            <option value="pt">Portuguese</option>
-            <option value="de">German</option>
-            <option value="it">Italian</option>
+             <option value="ar">Arabic</option>
+             <option value="bn">Bengali</option>
+             <option value="de">German</option>
+             <option value="en">English</option>
+             <option value="es">Spanish</option>
+             <option value="ff">Fula</option>
+             <option value="fr">French</option>
+             <option value="hi">Hindi</option>
+             <option value="id">Indonesian</option>
+             <option value="it">Italian</option>
+             <option value="ja">Japanese</option>
+             <option value="jv">Javanese</option>
+             <option value="pa">Punjabi</option>
+             <option value="pt">Portuguese</option>
+             <option value="ru">Russian</option>
+             <option value="tr">Turkish</option>
+             <option value="ur">Urdu</option>
+             <option value="vi">Vietnamese</option>
+             <option value="zh">Chinese</option>
           </select>
         </div>
     </div>
@@ -38,9 +51,15 @@ Please note that the translation option is only available for headwords. Also, r
           <label for="part_of_speech_tag">Part-of-speech tag</label>
           <select class="form-control" id="part_of_speech_tag" name="part_of_speech_tag">
             <option>Noun</option>
-            <option>Adjective</option>
-            <option>Adverb</option>
+            <option>Pronoun</option>
             <option>Verb</option>
+            <option>Adverb</option>
+            <option>Adjective</option>
+            <option>Quantitative</option>
+            <option>Interjection</option>
+            <option>Preposition</option>
+            <option>Article</option>
+            <option>Conjunction</option>            
           </select>
         </div>
     </div>
@@ -63,12 +82,25 @@ Please note that the translation option is only available for headwords. Also, r
           <label for="translation_languages">Translation language (only with Wikidata)</label>
           <select class="form-control" id="translation_languages" name="translation_languages">
             <option value="null"></option>
-            <option value="en">English</option>
-            <option value="fr">French</option>
-            <option value="es">Spanish</option>
-            <option value="pt">Portuguese</option>
-            <option value="de">German</option>
-            <option value="it">Italian</option>
+             <option value="ar">Arabic</option>
+             <option value="bn">Bengali</option>
+             <option value="de">German</option>
+             <option value="en">English</option>
+             <option value="es">Spanish</option>
+             <option value="ff">Fula</option>
+             <option value="fr">French</option>
+             <option value="hi">Hindi</option>
+             <option value="id">Indonesian</option>
+             <option value="it">Italian</option>
+             <option value="ja">Japanese</option>
+             <option value="jv">Javanese</option>
+             <option value="pa">Punjabi</option>
+             <option value="pt">Portuguese</option>
+             <option value="ru">Russian</option>
+             <option value="tr">Turkish</option>
+             <option value="ur">Urdu</option>
+             <option value="vi">Vietnamese</option>
+             <option value="zh">Chinese</option>
           </select>
         </div>
     </div>
@@ -110,13 +142,27 @@ Please note that the translation option is only available for headwords. Also, r
 
 <script>
   // https://www.wikidata.org/wiki/Help:Wikimedia_language_codes/lists/all
+  // https://w.wiki/4ZAZ
   var languages_wiki = {
-    "en": "Q1860",
-    "fr": "Q150",
-    "es": "Q1321",
-    "pt": "Q5146",
-    "de": "Q188",
-    "it": "Q652"
+    'ar': 'Q13955', // Arabic
+    'bn': 'Q9610', // Bengali
+    'de': 'Q188', // German
+    'en': 'Q1860', // English
+    'es': 'Q1321', // Spanish
+    'ff': 'Q33454', // Fula
+    'fr': 'Q150', // French
+    'hi': 'Q1568', // Hindi
+    'id': 'Q9240', // Indonesian
+    'it': 'Q652', // Italian
+    'ja': 'Q5287', // Japanese
+    'jv': 'Q33549', // Javanese
+    'pa': 'Q58635', // Punjabi
+    'pt': 'Q5146', // Portuguese
+    'ru': 'Q7737', // Russian
+    'tr': 'Q256', // Turkish
+    'ur': 'Q1617', // Urdu
+    'vi': 'Q9199', // Vietnamese
+    'zh': 'Q9192', // Chinese
   };
 
   var languages_dbnary = {
@@ -129,11 +175,18 @@ Please note that the translation option is only available for headwords. Also, r
   };
 
   var posTags = {
-    "Noun": "Q1084",
-    "Adjective": "Q34698",
-    "Adverb": "Q380057",
-    "Verb": "Q24905"
+    'Noun': 'Q1084',
+    'Pronoun': 'Q36224',
+    'Verb': 'Q24905',
+    'Adverb': 'Q380057',
+    'Adjective': 'Q34698',
+    'Quantitative': 'Q21087400'
+    'Interjection': '83034',
+    'Preposition': 'Q4833830',
+    'Article': 'Q103184',
+    'Conjunction': 'Q36484'
   };
+       
 
   // Queries for Wikidata
   var values = "\n\tVALUES ?word {'book'@GLWSSA}";

--- a/_posts/2021-10-04-sparql-query-generator-for-lexicographical-data.md
+++ b/_posts/2021-10-04-sparql-query-generator-for-lexicographical-data.md
@@ -180,7 +180,7 @@ Please note that the translation option is only available for headwords. Also, r
     'Verb': 'Q24905',
     'Adverb': 'Q380057',
     'Adjective': 'Q34698',
-    'Quantitative': 'Q21087400'
+    'Quantitative': 'Q21087400',
     'Interjection': 'Q83034',
     'Preposition': 'Q4833830',
     'Article': 'Q103184',

--- a/_posts/2021-10-04-sparql-query-generator-for-lexicographical-data.md
+++ b/_posts/2021-10-04-sparql-query-generator-for-lexicographical-data.md
@@ -181,7 +181,7 @@ Please note that the translation option is only available for headwords. Also, r
     'Adverb': 'Q380057',
     'Adjective': 'Q34698',
     'Quantitative': 'Q21087400'
-    'Interjection': '83034',
+    'Interjection': 'Q83034',
     'Preposition': 'Q4833830',
     'Article': 'Q103184',
     'Conjunction': 'Q36484'

--- a/_posts/2021-10-04-sparql-query-generator-for-lexicographical-data.md
+++ b/_posts/2021-10-04-sparql-query-generator-for-lexicographical-data.md
@@ -199,7 +199,7 @@ Please note that the translation option is only available for headwords. Also, r
 
   var queryExamplesWiki = "SELECT * WHERE {VALUESTOBEADDEDHERE\n\t?l a ontolex:LexicalEntry ;\n\t\tdct:language wd:LNGCDE ;\n\t\twikibase:lemma ?lemma ;\n\t\tontolex:lexicalForm ?form ;\n\t\twikibase:lexicalCategory ?category ;\n\t\tontolex:sense ?sense .\n\t\t?language wdt:P218 \"GLWSSA\" .\n\t?form ontolex:representation ?word .\n\t?sense skos:definition ?gloss .\n\tOPTIONAL{\n\t\t?l p:P5831 ?statement .\n\t\t?statement ps:P5831 ?example .\n\t}\n\tFILTER EXISTS {?l ontolex:sense ?sense }\n\tFILTER(LANG(?gloss) = \"GLWSSA\")\n}";
 
-  var queryTranslationWiki = "SELECT DISTINCT * WHERE {\n\t?sourec dct:language wd:LNGCDE;\n\t\twikibase:lemma ?sourceLemma;\n\t\tontolex:sense [ wdt:P5137 ?sense ].\n\t?target dct:language wd:LNGCDETRG;\n\t\twikibase:lemma ?targetLemma;\n\t\tontolex:sense [ wdt:P5137 ?sense ].\n}\nORDER BY ASC(UCASE(str(?sourceLemma)))\nLIMIT 100 ";
+  var queryTranslationWiki = "SELECT DISTINCT * WHERE {\n\t?source dct:language wd:LNGCDE;\n\t\twikibase:lemma ?sourceLemma;\n\t\tontolex:sense [ wdt:P5137 ?sense ].\n\t?target dct:language wd:LNGCDETRG;\n\t\twikibase:lemma ?targetLemma;\n\t\tontolex:sense [ wdt:P5137 ?sense ].\n}\nORDER BY ASC(UCASE(str(?sourceLemma)))\nLIMIT 100 ";
 
   var queryTranslationWikiLemma = "SELECT DISTINCT * WHERE {VALUESTOBEADDEDHERE\n\t?source dct:language wd:LNGCDE;\n\t\twikibase:lemma ?sourceLemma;\n\t\tontolex:lexicalForm ?form ;\n\t\twikibase:lexicalCategory wd:POSTAG ;\n\t\tontolex:sense [ wdt:P5137 ?sense ].\n\t?target dct:language wd:LNGCDETRG;\n\t\twikibase:lemma ?targetLemma;\n\t\tontolex:sense [ wdt:P5137 ?sense ].\n\t?form ontolex:representation ?word .\n}\nORDER BY ASC(UCASE(str(?sourceLemma))) ";
 

--- a/_posts/2021-10-04-sparql-query-generator-for-lexicographical-data.md
+++ b/_posts/2021-10-04-sparql-query-generator-for-lexicographical-data.md
@@ -73,7 +73,7 @@ Please note that the translation option is only available for headwords. Also, r
             <option value="1">Just look it up!</option>
             <option value="2">Senses</option>
             <option value="3">Senses & Definitions</option>
-            <option value="4">Senses, Deinitions & Examples</option>
+            <option value="4">Senses, Definitions & Examples</option>
           </select>
         </div>
     </div>


### PR DESCRIPTION
List of language wikidata Qid, names, iso 639-1 for language with 80M+ speakers, selected from https://w.wiki/4ZAZ,
List of part of speech, most common POS, selected from https://w.wiki/4Y2o
Important: Dbnary has not been modified since I do not know this system.

A additional PR for code cleanup will come later (demo at https://jsfiddle.net/hugolpz/rygo9s5b/ ).